### PR TITLE
Added option to pass in device serial number as argument

### DIFF
--- a/src/com/adakoda/android/asm/AndroidScreenMonitor.java
+++ b/src/com/adakoda/android/asm/AndroidScreenMonitor.java
@@ -18,21 +18,25 @@ package com.adakoda.android.asm;
 import javax.swing.SwingUtilities;
 
 public class AndroidScreenMonitor {
-	
+
 	private MainFrame mMainFrame;
 	private static String[] mArgs;
 
 	public AndroidScreenMonitor() {
 	}
-	
+
 	public void initialize() {
 		mMainFrame = new MainFrame(mArgs);
 		mMainFrame.setLocationRelativeTo(null);
 		mMainFrame.setVisible(true);
 		mMainFrame.setFocusable(true);
-		mMainFrame.selectDevice();
+		if(mArgs != null && mArgs.length > 1) {
+			mMainFrame.setSelectedDevice(mArgs[1]);
+		} else {
+			mMainFrame.selectDevice();
+		}
 	}
-	
+
 	public static void main(String[] args) {
 		mArgs = args;
         SwingUtilities.invokeLater(new Runnable() {

--- a/src/com/adakoda/android/asm/MainFrame.java
+++ b/src/com/adakoda/android/asm/MainFrame.java
@@ -69,9 +69,9 @@ import com.android.ddmlib.TimeoutException;
 public class MainFrame extends JFrame {
 	private static final int DEFAULT_WIDTH = 320;
 	private static final int DEFAULT_HEIGHT = 480;
-	
+
 	private static final String EXT_PNG = "png";
-	
+
 	private static final int FB_TYPE_XBGR = 0;
 	private static final int FB_TYPE_RGBX = 1;
 	private static final int FB_TYPE_XRGB = 2;
@@ -81,7 +81,7 @@ public class MainFrame extends JFrame {
 			{3, 2, 1, 0}, // RGBX : Xperia Arc
 			{2, 1, 0, 3}  // XRGB : FireFox OS(B2G)
 	};
-	
+
 	private MainPanel mPanel;
 	private JPopupMenu mPopupMenu;
 
@@ -112,6 +112,26 @@ public class MainFrame extends JFrame {
 
 	public void stopMonitor() {
 		mMonitorThread = null;
+	}
+
+	public void setSelectedDevice(String device) {
+		stopMonitor();
+		mDevices = mADB.getDevices();
+		for(int i = 0; i < mDevices.length; ++i ) {
+			if(mDevices[i].toString().equals(device)) {
+				mDevice = mDevices[i];
+				setImage(null);
+				mChimpDevice = new AdbChimpDevice(mDevice);
+				mBuildDevice = mChimpDevice.getProperty("build.device");
+				startMonitor();
+				return;
+			}
+		}
+
+		if(mDevice == null) {
+			selectDevice();
+		}
+
 	}
 
 	public void selectDevice() {
@@ -163,7 +183,7 @@ public class MainFrame extends JFrame {
 			savePrefs();
 		}
 	}
-	
+
 	public void saveImage() {
 		FBImage inImage = mPanel.getFBImage();
 		if (inImage != null) {
@@ -253,7 +273,7 @@ public class MainFrame extends JFrame {
 		}
 
 		parseArgs(args);
-		
+
 		initializePrefs();
 		initializeFrame();
 		initializePanel();
@@ -283,7 +303,7 @@ public class MainFrame extends JFrame {
 			}
 		}
 	}
-	
+
 	private void savePrefs() {
 		if (mPrefs != null) {
 			mPrefs.putInt("PrefVer", 1);
@@ -292,7 +312,7 @@ public class MainFrame extends JFrame {
 			mPrefs.putInt("FbType", mFbType);
 		}
 	}
-	
+
 	private void initializePrefs() {
 		mPrefs = Preferences.userNodeForPackage(this.getClass());
 		if (mPrefs != null) {
@@ -304,7 +324,7 @@ public class MainFrame extends JFrame {
 			}
 		}
 	}
-	
+
 	private void initializeFrame() {
 		setTitle("Android Screen Monitor");
 		setIconImage(Toolkit.getDefaultToolkit().getImage(
@@ -427,7 +447,7 @@ public class MainFrame extends JFrame {
 		buttonGroup.add(radioButtonMenuItemZoom);
 		menuZoom.add(radioButtonMenuItemZoom);
 	}
-	
+
 	private void initializeFrameBufferMenu() {
 		JMenu menuZoom = new JMenu("FrameBuffer");
 		menuZoom.setMnemonic(KeyEvent.VK_F);
@@ -794,7 +814,7 @@ public class MainFrame extends JFrame {
 			return mFBImage;
 		}
 	}
-	
+
 	public class MonitorThread extends Thread {
 
 		@Override
@@ -921,7 +941,7 @@ public class MainFrame extends JFrame {
 				final int offset1;
 				final int offset2;
 				final int offset3;
-				
+
 				if (rawImage.bpp == 16) {
 					offset0 = 0;
 					offset1 = 1;
@@ -959,7 +979,7 @@ public class MainFrame extends JFrame {
 					offset0 = FB_OFFSET_LIST[mFbType][0];
 					offset1 = FB_OFFSET_LIST[mFbType][1];
 					offset2 = FB_OFFSET_LIST[mFbType][2];
-					offset3 = FB_OFFSET_LIST[mFbType][3];					
+					offset3 = FB_OFFSET_LIST[mFbType][3];
 					if (mPortrait) {
 						int[] lineBuf = new int[rawImage.width];
 						for (int y = 0; y < rawImage.height; y++) {
@@ -1012,7 +1032,7 @@ public class MainFrame extends JFrame {
 
 			return fbImage;
 		}
-		
+
 		public int getMask(int length) {
 	        int res = 0;
 	        for (int i = 0 ; i < length ; i++) {


### PR DESCRIPTION
The first argument is the path to the android sdk. I have added support for a second argument to be the device serial number. If the device serial number is passed, it will use that device to connect to and not prompt the user to select a device.

ps: not sure where there are additional blank lines added. It may be from a conversion from different OS line breaks. 